### PR TITLE
feat(57): 리뷰 정렬 기준 개선 및 수정 시 빈 폼 렌더링 오류 해결

### DIFF
--- a/backend/src/main/java/com/tripfriend/domain/review/repository/ReviewRepository.kt
+++ b/backend/src/main/java/com/tripfriend/domain/review/repository/ReviewRepository.kt
@@ -8,41 +8,80 @@ import org.springframework.stereotype.Repository
 @Repository
 interface ReviewRepository : JpaRepository<Review, Long> {
 
-    // 댓글 수를 기준으로 리뷰 정렬 (많은 순)
-    @Query("SELECT r, COUNT(c) as commentCount FROM Review r LEFT JOIN Comment c ON r.reviewId = c.review.reviewId GROUP BY r ORDER BY commentCount DESC")
-    fun findAllOrderByCommentCountDesc(): List<Array<Any>>
-
-    // 평점 높은 순으로 정렬
-    fun findAllByOrderByRatingDesc(): List<Review>
-
-    // 평점 낮은 순으로 정렬
-    fun findAllByOrderByRatingAsc(): List<Review>
-
-    // 최신순 정렬 - 기본값
-    fun findAllByOrderByCreatedAtDesc(): List<Review>
-
-    // 오래된순 정렬
-    fun findAllByOrderByCreatedAtAsc(): List<Review>
-
-    // 제목으로 검색
-    fun findByTitleContainingOrderByCreatedAtDesc(keyword: String): List<Review>
-
-    // 여행지 ID로 검색 (최신순)
-    fun findByPlace_IdOrderByCreatedAtDesc(placeId: Long): List<Review>
-
-    // 여행지 ID로 검색 (오래된순)
-    fun findByPlace_IdOrderByCreatedAtAsc(placeId: Long): List<Review>
-
-    // 여행지 ID + 정렬 옵션 (평점 높은 순)
-    fun findByPlace_IdOrderByRatingDesc(placeId: Long): List<Review>
-
-    // 여행지 ID + 정렬 옵션 (평점 낮은 순)
-    fun findByPlace_IdOrderByRatingAsc(placeId: Long): List<Review>
-
-    // 여행지 ID + 정렬 옵션 (댓글 많은순)
-    @Query("SELECT r FROM Review r LEFT JOIN Comment c ON r.reviewId = c.review.reviewId WHERE r.place.id = :placeId GROUP BY r ORDER BY COUNT(c) DESC")
+    // 특정 여행지 - 댓글 많은순 -> 최신순 정렬
+    @Query("""
+        SELECT r 
+        FROM Review r 
+        LEFT JOIN Comment c ON r.reviewId = c.review.reviewId 
+        WHERE r.place.id = :placeId 
+        GROUP BY r 
+        ORDER BY COUNT(c) DESC, r.createdAt DESC
+    """)
     fun findByPlace_IdOrderByCommentCountDesc(placeId: Long): List<Review>
 
-    // 특정 사용자의 리뷰 목록
+    // 특정 여행지 - 평점 높은순 -> 조회수 많은순 -> 최신순
+    @Query("""
+        SELECT r 
+        FROM Review r
+        LEFT JOIN ReviewViewCount vc ON r.reviewId = vc.reviewId
+        WHERE r.place.id = :placeId 
+        ORDER BY r.rating DESC, vc.count DESC, r.createdAt DESC
+    """)
+    fun findByPlace_IdOrderByRatingDesc(placeId: Long): List<Review>
+
+    // 특정 여행지 - 평점 낮은순 -> 조회수 많은순 -> 최신순
+    @Query("""
+        SELECT r 
+        FROM Review r
+        LEFT JOIN ReviewViewCount vc ON r.reviewId = vc.reviewId
+        WHERE r.place.id = :placeId 
+        ORDER BY r.rating ASC, vc.count DESC, r.createdAt DESC
+    """)
+    fun findByPlace_IdOrderByRatingAsc(placeId: Long): List<Review>
+
+    // 특정 여행지 - 최신순
+    fun findByPlace_IdOrderByCreatedAtDesc(placeId: Long): List<Review>
+
+    // 특정 여행지 - 오래된순
+    fun findByPlace_IdOrderByCreatedAtAsc(placeId: Long): List<Review>
+
+    // 전체 - 평점 높은순 -> 조회수 많은순 -> 최신순
+    @Query("""
+        SELECT r 
+        FROM Review r
+        LEFT JOIN ReviewViewCount vc ON r.reviewId = vc.reviewId
+        ORDER BY r.rating DESC, vc.count DESC, r.createdAt DESC
+    """)
+    fun findAllByOrderByRatingDesc(): List<Review>
+
+    // 전체 - 평점 낮은순 -> 조회수 많은순 -> 최신순
+    @Query("""
+        SELECT r 
+        FROM Review r
+        LEFT JOIN ReviewViewCount vc ON r.reviewId = vc.reviewId
+        ORDER BY r.rating ASC, vc.count DESC, r.createdAt DESC
+    """)
+    fun findAllByOrderByRatingAsc(): List<Review>
+
+    // 전체 - 최신순
+    fun findAllByOrderByCreatedAtDesc(): List<Review>
+
+    // 전체 - 오래된순
+    fun findAllByOrderByCreatedAtAsc(): List<Review>
+
+    // keyword 포함된 리뷰를 최신순으로 정렬
+    fun findByTitleContainingOrderByCreatedAtDesc(keyword: String): List<Review>
+
+    // 특정 멤버의 리뷰 목록 최신순
     fun findByMemberIdOrderByCreatedAtDesc(memberId: Long): List<Review>
+
+    // 전체 리뷰 댓글 많은순 → 최신순 정렬
+    @Query("""
+        SELECT r, COUNT(c) as commentCount 
+        FROM Review r 
+        LEFT JOIN Comment c ON r.reviewId = c.review.reviewId 
+        GROUP BY r 
+        ORDER BY commentCount DESC, r.createdAt DESC
+    """)
+    fun findAllOrderByCommentCountDesc(): List<Array<Any>>
 }

--- a/backend/src/main/java/com/tripfriend/domain/review/repository/ReviewRepository.kt
+++ b/backend/src/main/java/com/tripfriend/domain/review/repository/ReviewRepository.kt
@@ -27,14 +27,21 @@ interface ReviewRepository : JpaRepository<Review, Long> {
     // 제목으로 검색
     fun findByTitleContainingOrderByCreatedAtDesc(keyword: String): List<Review>
 
-    // 여행지 ID로 검색
+    // 여행지 ID로 검색 (최신순)
     fun findByPlace_IdOrderByCreatedAtDesc(placeId: Long): List<Review>
+
+    // 여행지 ID로 검색 (오래된순)
+    fun findByPlace_IdOrderByCreatedAtAsc(placeId: Long): List<Review>
 
     // 여행지 ID + 정렬 옵션 (평점 높은 순)
     fun findByPlace_IdOrderByRatingDesc(placeId: Long): List<Review>
 
     // 여행지 ID + 정렬 옵션 (평점 낮은 순)
     fun findByPlace_IdOrderByRatingAsc(placeId: Long): List<Review>
+
+    // 여행지 ID + 정렬 옵션 (댓글 많은순)
+    @Query("SELECT r FROM Review r LEFT JOIN Comment c ON r.reviewId = c.review.reviewId WHERE r.place.id = :placeId GROUP BY r ORDER BY COUNT(c) DESC")
+    fun findByPlace_IdOrderByCommentCountDesc(placeId: Long): List<Review>
 
     // 특정 사용자의 리뷰 목록
     fun findByMemberIdOrderByCreatedAtDesc(memberId: Long): List<Review>

--- a/frontend/src/app/community/edit/[id]/page.tsx
+++ b/frontend/src/app/community/edit/[id]/page.tsx
@@ -13,8 +13,12 @@ export const metadata: Metadata = {
   title: "TripFriend - 리뷰 수정",
   description: "작성한 여행 리뷰를 수정합니다.",
 }
-
-export default function EditReviewPage({ params }: EditReviewPageProps) {
+// 서버 컴포넌트를 async로 선언
+export default async function EditReviewPage({ params }: EditReviewPageProps) {
+  // 동적 라우트 파라미터에 접근하기 전에 async/await 패턴을 사용
+  // params 객체가 완전히 로드될 때까지 기다립니다
+  const resolvedParams = await Promise.resolve(params);
+  const id = resolvedParams.id;
   return (
     <div className="min-h-screen bg-gray-50">
       <div className="bg-blue-600 text-white">
@@ -29,8 +33,8 @@ export default function EditReviewPage({ params }: EditReviewPageProps) {
       <div className="container mx-auto px-4 py-8">
         <div className="max-w-4xl mx-auto">
           <Suspense fallback={<div className="text-center py-10">리뷰 정보를 불러오는 중...</div>}>
-            <EditAuthCheck reviewId={params.id}>
-              <ReviewForm reviewId={params.id} />
+            <EditAuthCheck reviewId={id}>
+              <ReviewForm reviewId={id} />
             </EditAuthCheck>
           </Suspense>
         </div>

--- a/frontend/src/app/community/review-form.tsx
+++ b/frontend/src/app/community/review-form.tsx
@@ -92,35 +92,40 @@ export default function ReviewForm({ reviewId }: ReviewFormProps) {
     fetchPlaces();
   }, []);
 
-  // 수정 모드일 경우 리뷰 데이터 가져오기
-  useEffect(() => {
-    if (isEditMode && reviewId) {
-      const fetchReview = async () => {
-        try {
-          const review = await getReviewById(parseInt(reviewId));
+// 수정 모드일 경우 리뷰 데이터 가져오기
+useEffect(() => {
+  if (!isEditMode || !reviewId) return;
 
-          setFormData({
-            title: review.title,
-            content: review.content,
-            rating: review.rating,
-            placeId: review.placeId.toString(),
-            images: [],
-          });
+  const fetchReview = async () => {
+    try {
+      const parsedId = parseInt(reviewId);
+      if (isNaN(parsedId)) {
+        setFormError("잘못된 리뷰 ID입니다.");
+        return;
+      }
 
-          // 이미지 URL이 있다면 프리뷰 이미지 설정
-          // 백엔드에서 이미지 URL을 제공하는 경우에만 활성화
-          // if (review.images && review.images.length > 0) {
-          //   setPreviewImages(review.images);
-          // }
-        } catch (err) {
-          console.error("리뷰 정보를 불러오는 중 오류가 발생했습니다:", err);
-          setFormError("리뷰 정보를 불러오는 중 오류가 발생했습니다.");
-        }
-      };
+      const review = await getReviewById(parsedId);
 
-      fetchReview();
+      setFormData({
+        title: review.title ?? "",
+        content: review.content ?? "",
+        rating: review.rating ?? 0,
+        placeId: review.placeId?.toString() ?? "",
+        images: [],
+      });
+
+      // 👉 이미지 URL 프리뷰가 있다면 이곳에서 처리
+      // if (review.images && review.images.length > 0) {
+      //   setPreviewImages(review.images);
+      // }
+    } catch (err) {
+      console.error("리뷰 정보를 불러오는 중 오류가 발생했습니다:", err);
+      setFormError("리뷰 정보를 불러오는 데 실패했습니다. 다시 시도해주세요.");
     }
-  }, [isEditMode, reviewId]);
+  };
+
+  fetchReview();
+}, [isEditMode, reviewId]);
 
   // 입력값 변경 처리
   const handleInputChange = (


### PR DESCRIPTION


## 🔎 작업 내용
### ✅ 리뷰 정렬 기능 개선
- 평점 높은순/낮은순 정렬 시: 조회수 → 최신순으로 2차, 3차 정렬 기준 적용
- 조회수순 정렬 시: 최신순을 2차 정렬로 적용
- 댓글수 기준 정렬: 최신순을 2차 정렬로 적용
### 🐛 리뷰 수정 기능 오류 해결
- 기존 리뷰 수정 시, 폼에 기존 내용이 표시되지 않는 문제 수정

  <br/>


## ➕ 이슈 링크
- [리뷰 게시판 정렬 옵션 오류 수정 #57 ](https://github.com/prgrms-be-devcourse/NBE4-5-3-Team10/issues/57)

<br/>

<!-- closed #57  -->
